### PR TITLE
fix: return Identity errors on user creation failure

### DIFF
--- a/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
@@ -4,6 +4,16 @@ public record UserDto(string Id, string UserName, string Email, string FirstName
 
 public record CreateUserRequest(string UserName, string Email, string Password, string FirstName, string LastName, string Role, int[] Teams);
 
+public record UserError(string Code, string Description);
+
+public record CreateUserResult(UserDto? User, IReadOnlyList<UserError> Errors)
+{
+    public bool Succeeded => User != null;
+
+    public static CreateUserResult Success(UserDto user) => new(user, []);
+    public static CreateUserResult Failure(IReadOnlyList<UserError> errors) => new(null, errors);
+}
+
 public record AssignRoleRequest(string Role);
 
 public record AssignTeamsRequest(int[] TeamIds);
@@ -14,7 +24,7 @@ public interface IUserService
     Task<IList<UserDto>> GetTeamMembersAsync(int[] teamIds);
     Task<IList<UserDto>> GetCoachesForTeamsAsync(int[] teamIds);
     Task<UserDto?> GetUserByIdAsync(string userId);
-    Task<UserDto?> CreateUserAsync(CreateUserRequest request);
+    Task<CreateUserResult> CreateUserAsync(CreateUserRequest request);
     Task<bool> AssignRoleAsync(string userId, string role);
     Task<bool> AssignTeamsAsync(string userId, int[] teamIds);
 }

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
@@ -171,7 +171,7 @@ public class UserControllerTests
     public async Task CreateUser_ReturnsCreatedUser()
     {
         var request = new CreateUserRequest("alice", "alice@test.local", "Pass123!", "Alice", "Smith", "learner", [1]);
-        _userService.CreateUserAsync(request).Returns(Alice);
+        _userService.CreateUserAsync(request).Returns(CreateUserResult.Success(Alice));
 
         var result = await _sut.CreateUser(request);
 
@@ -181,14 +181,17 @@ public class UserControllerTests
     }
 
     [Test]
-    public async Task CreateUser_WhenServiceReturnsNull_ReturnsBadRequest()
+    public async Task CreateUser_WhenServiceFails_ReturnsBadRequestWithErrors()
     {
         var request = new CreateUserRequest("alice", "alice@test.local", "weak", "Alice", "Smith", "learner", []);
-        _userService.CreateUserAsync(request).Returns((UserDto?)null);
+        var errors = new[] { new UserError("PasswordTooShort", "Password must be at least 8 characters.") };
+        _userService.CreateUserAsync(request).Returns(CreateUserResult.Failure(errors));
 
         var result = await _sut.CreateUser(request);
 
-        Assert.That(result.Result, Is.TypeOf<BadRequestResult>());
+        var badRequest = result.Result as BadRequestObjectResult;
+        Assert.That(badRequest, Is.Not.Null);
+        Assert.That(badRequest!.Value, Is.InstanceOf<IReadOnlyList<UserError>>());
     }
 
     // PUT /api/user/{id}/role

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
@@ -81,13 +81,13 @@ public class UserController : ControllerBase
     [Authorize(Roles = "backoffice")]
     public async Task<ActionResult<UserDto>> CreateUser(CreateUserRequest request)
     {
-        var user = await _userService.CreateUserAsync(request);
-        if (user == null)
+        var result = await _userService.CreateUserAsync(request);
+        if (!result.Succeeded)
         {
-            return BadRequest();
+            return BadRequest(result.Errors);
         }
 
-        return CreatedAtAction(nameof(GetUserById), new { userId = user.Id }, user);
+        return CreatedAtAction(nameof(GetUserById), new { userId = result.User!.Id }, result.User);
     }
 
     /// <summary>

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
@@ -81,7 +81,7 @@ public class UserService : IUserService
         return user == null ? null : await ToDto(user);
     }
 
-    public async Task<UserDto?> CreateUserAsync(CreateUserRequest request)
+    public async Task<CreateUserResult> CreateUserAsync(CreateUserRequest request)
     {
         var user = new ForgeUser
         {
@@ -95,7 +95,10 @@ public class UserService : IUserService
         var result = await _userManager.CreateAsync(user, request.Password);
         if (!result.Succeeded)
         {
-            return null;
+            var errors = result.Errors
+                .Select(e => new UserError(e.Code, e.Description))
+                .ToList();
+            return CreateUserResult.Failure(errors);
         }
 
         await _userManager.AddToRoleAsync(user, request.Role);
@@ -104,7 +107,7 @@ public class UserService : IUserService
             await _userManager.AddClaimAsync(user, new Claim("team", teamId.ToString(CultureInfo.InvariantCulture)));
         }
 
-        return await ToDto(user);
+        return CreateUserResult.Success(await ToDto(user));
     }
 
     public async Task<bool> AssignRoleAsync(string userId, string role)

--- a/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
+++ b/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
@@ -118,7 +118,19 @@ function CreateUserSheet({
       form.reset();
       onOpenChange(false);
     },
-    onError: () => toast.error(t('users.createError', 'Failed to create user')),
+    onError: (error: unknown) => {
+      const data = (error as { response?: { data?: unknown } })?.response?.data;
+      let detail = '';
+      if (Array.isArray(data)) {
+        detail = (data as { description?: string; code?: string }[])
+          .map((e) => e.description ?? e.code ?? '')
+          .filter(Boolean)
+          .join('\n');
+      } else if (typeof data === 'string') {
+        detail = data;
+      }
+      toast.error(t('users.createError', 'Failed to create user'), { description: detail || undefined });
+    },
   });
 
   const selectedTeams = form.watch('teams');


### PR DESCRIPTION
## Summary
- Add `UserError` and `CreateUserResult` types to `IUserService` so errors are propagated instead of swallowed
- `UserService` returns Identity error details (code + description) on creation failure
- `UserController` returns `BadRequest` with error array instead of empty 400
- Frontend toast shows the error descriptions from the API response (e.g. "Password must be at least 8 characters.")

## Test plan
- [ ] Create user with a weak password → toast shows Identity error description
- [ ] Create user with a duplicate username → toast shows duplicate error
- [ ] Create user with valid data → succeeds as before
- [ ] Backend tests pass: `dotnet test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)